### PR TITLE
ci: add GitHub Actions workflow for check, clippy, test, doc

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  check:
+    name: Check (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Check
+        run: cargo check --workspace
+      - name: Clippy
+        run: cargo clippy --workspace -- -D warnings
+      - name: Test
+        run: cargo test --workspace
+      - name: Doc
+        run: cargo doc --workspace --no-deps


### PR DESCRIPTION
Add comprehensive CI pipeline for portus Rust project.

## Changes
- Add GitHub Actions workflow ()
- Runs on: push to main, pull requests to main
- Tests on: macOS (macos-latest) and Linux (ubuntu-latest)
- Steps: check, clippy, test, doc
- Uses Rust stable toolchain with clippy component
- Caches cargo dependencies for speed

## Verification
- All 43 tests pass locally (28 unit + 9 MCP unit + 3 daemon integration + 3 MCP integration)
- Clippy clean with `-D warnings`
- Cargo check, test, and doc all pass

## Notes
- Unix-only features (UDS, signals) tested on both macOS and Linux
- Windows deferred (abstraction exists but untested)
- No code coverage or release steps (follow-up work)