### PR TITLE
ci: add timeout and fail-fast for reliable CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,9 @@ jobs:
   check:
     name: Check (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 15
     strategy:
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:


### PR DESCRIPTION
## Summary
- Add `timeout-minutes: 15` to prevent hung integration tests from blocking CI indefinitely
- Add `fail-fast: false` so both Ubuntu and macOS jobs always run (helps debug platform-specific issues)
- Validates that the CI fix from 409c6ac (build workspace before test) works correctly

## Context
The original CI run at 3f9fcce failed because integration tests couldn't find the `portusd` binary — `cargo test` doesn't build all workspace binaries. The fix (adding `cargo build --workspace` before `cargo test`) was pushed directly to main at 409c6ac and validated via PR #4, but the old failure still shows in the Actions tab. This PR gives CI a clean run with the improved workflow.